### PR TITLE
Keep ubuntu apt repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN apt-get update \
  && apt-get install -y libssl1.0.0 libnuma1 \
  && tar -C /tmp/ -xvzf /tmp/vpp-debs.tar.gz \
  && dpkg -i /tmp/vpp-lib_*.deb /tmp/vpp_*.deb /tmp/vpp-plugins_*.deb \
- && rm -rf /tmp/*.deb /tmp/vpp-debs.tar.gz /var/lib/apt/lists/*
+ && rm -rf /tmp/*.deb /tmp/vpp-debs.tar.gz


### PR DESCRIPTION
Since the vpp-base is used as base image, there would be a requirement
the image uses it as base could install packages, hence here keeps
the repo sources and give the clean task to the image that basing
on it.