### PR TITLE
Setting up vpp-base-builder docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,7 @@
-FROM ubuntu:16.04 as builder
+ARG BUILDER_IMAGE
+FROM ${BUILDER_IMAGE} as builder
 
-RUN apt-get update \
- && apt-get install -y \
-    git build-essential software-properties-common sudo \
- && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
- && apt-get update \
- && apt-get install -y gcc-7 \
- && cd /usr/bin/ \
- && rm gcc \
- && ln -s gcc-7 gcc \
- && git clone https://gerrit.fd.io/r/vpp /vpp
-
-ADD build.env /
-
-RUN . /build.env \
- && cd /vpp \
- && git pull \
- && git checkout ${VPP_COMMIT} \
- && UNATTENDED=y make install-dep bootstrap pkg-deb \
- && cd build-root \
+RUN cd /vpp/build-root \
  && bash -c "tar -czvf vpp-debs.tar.gz {vpp,vpp-plugins,vpp-lib}_$(git describe --tags | sed -e s/-/~/2 -e s/^v//)_amd64.deb"
 
 FROM ubuntu:16.04

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,0 +1,22 @@
+FROM ubuntu:16.04
+
+RUN apt-get update \
+ && apt-get install -y \
+    git build-essential software-properties-common sudo \
+ && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+ && apt-get update \
+ && apt-get install -y gcc-7 \
+ && cd /usr/bin/ \
+ && rm gcc \
+ && ln -s gcc-7 gcc \
+ && git clone https://gerrit.fd.io/r/vpp /vpp
+
+ADD build.env /
+
+RUN . /build.env \
+ && cd /vpp \
+ && git pull \
+ && git checkout ${VPP_COMMIT} \
+ && UNATTENDED=y make install-dep bootstrap pkg-deb \
+ && cd build-root \
+ && bash -c "dpkg -i {vpp,vpp-plugins,vpp-lib,vpp-dev}_$(git describe --tags | sed -e s/-/~/2 -e s/^v//)_amd64.deb"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
-include build.env
+#!/usr/bin/env make
 
 IMAGE_PATH ?= contiv/vpp-base
-IMAGE_TAG := $(shell echo $(VPP_COMMIT) | head -c 8)
 
 build:
-	echo $(IMAGE_TAG)
-	docker build -t "$(IMAGE_PATH):$(IMAGE_TAG)" .
-	docker tag "$(IMAGE_PATH):$(IMAGE_TAG)" "$(IMAGE_PATH):latest"
+	DOCKER_REPO=$(IMAGE_PATH) hooks/build
 
 .PHONY: build

--- a/build.env
+++ b/build.env
@@ -1,1 +1,13 @@
+# vpp commit id to build
 export VPP_COMMIT=b59bd659388db62b60a4fb887ce272989d7c340c
+
+# vpp build args
+export VPP_BUILD_ARGS="UNATTENDED=y"
+
+if [ -z "${IMAGE_REPO}" ]; then
+    export IMAGE_REPO=${DOCKER_REPO}
+fi
+
+if [ -z "${IMAGE_BUILDER_REPO}" ]; then
+    export IMAGE_BUILDER_REPO=${IMAGE_REPO}-builder
+fi

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+. build.env
+
+set -xueo pipefail
+
+IMAGE_TAG="${VPP_COMMIT:0:8}"
+
+docker build --no-cache -f Dockerfile-builder -t ${IMAGE_BUILDER_REPO}:${IMAGE_TAG} .
+docker build --no-cache --build-arg BUILDER_IMAGE="${IMAGE_BUILDER_REPO}:${IMAGE_TAG}" -f Dockerfile -t ${IMAGE_REPO}:${IMAGE_TAG} .

--- a/hooks/push
+++ b/hooks/push
@@ -2,8 +2,9 @@
 
 . build.env
 
+set -xueo pipefail
+
 IMAGE_TAG="${VPP_COMMIT:0:8}"
 
-docker tag ${IMAGE_NAME} ${DOCKER_REPO}:${IMAGE_TAG}
-
-docker push ${DOCKER_REPO}:${IMAGE_TAG}
+docker push ${IMAGE_BUILDER_REPO}:${IMAGE_TAG}
+docker push ${IMAGE_REPO}:${IMAGE_TAG}


### PR DESCRIPTION
We need vpp-base-builder container that has all vpp dependencies
installed, so that we could compile vpp-agent correctly
(needs vpp-dev).
This commit separates "vpp-base" and "vpp-base-builder" image build,
the later would only be used for compile codes that require dev
dependencies.