### PR TITLE
Only copies libvcl_ldpreload.so.0.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ RUN cd /vpp/build-root \
 
 FROM ubuntu:16.04
 
+ENV LD_PRELOAD_LIB_DIR /opt/ldpreload
+
 COPY --from=builder /vpp/build-root/vpp-debs.tar.gz /tmp/vpp-debs.tar.gz
-COPY --from=builder /vpp/build-root/install-vpp-native/vpp/lib64 /opt/ldpreload
+COPY --from=builder /vpp/build-root/install-vpp-native/vpp/lib64/libvcl_ldpreload.so.0.0.0 ${LD_PRELOAD_LIB_DIR}/
+
 
 RUN apt-get update \
  && apt-get install -y libssl1.0.0 libnuma1 \


### PR DESCRIPTION
The libvcl_ldpreload.so.0.0.0 file is the only one we need to copy
onto the runner image, and also env `LD_PRELOAD_LIB_DIR` needs to
be defined in order to make the initContainer copy the .so file
onto right place.

See: https://github.com/contiv/vpp/pull/555#issuecomment-362183064
for more details