### PR TITLE
Revert "disable-japi,vom,papi"

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -17,6 +17,6 @@ RUN . /build.env \
  && cd /vpp \
  && git pull \
  && git checkout ${VPP_COMMIT} \
- && UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom --disable-papi' install-dep bootstrap pkg-deb \
+ && UNATTENDED=y make install-dep bootstrap pkg-deb \
  && cd build-root \
  && bash -c "dpkg -i {vpp,vpp-plugins,vpp-lib,vpp-dev}_$(git describe --tags | sed -e s/-/~/2 -e s/^v//)_amd64.deb"


### PR DESCRIPTION
With disable-japi,vom,papi, the build process will not include
"vpp-api/client/vppapiclient.h" in vpp-dev package, as a result
the vpp-agent would not able to be compiled.
This reverts commit 714c50b6dfa24d9a4084244a9c6a434b7225e8dd.