### PR TITLE
hooks/build: force pulling the image on build

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -6,5 +6,5 @@ set -xueo pipefail
 
 IMAGE_TAG="${VPP_COMMIT:0:8}"
 
-docker build --no-cache -f Dockerfile-builder -t ${IMAGE_BUILDER_REPO}:${IMAGE_TAG} .
-docker build --no-cache --build-arg BUILDER_IMAGE="${IMAGE_BUILDER_REPO}:${IMAGE_TAG}" -f Dockerfile -t ${IMAGE_REPO}:${IMAGE_TAG} .
+docker build --no-cache --pull -f Dockerfile-builder -t ${IMAGE_BUILDER_REPO}:${IMAGE_TAG} .
+docker build --no-cache --pull --build-arg BUILDER_IMAGE="${IMAGE_BUILDER_REPO}:${IMAGE_TAG}" -f Dockerfile -t ${IMAGE_REPO}:${IMAGE_TAG} .


### PR DESCRIPTION
This ensures we don't use a stale base image.