### PR TITLE
Skip building C++/Java API (saving ~1.2GB)

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -17,6 +17,6 @@ RUN . /build.env \
  && cd /vpp \
  && git pull \
  && git checkout ${VPP_COMMIT} \
- && UNATTENDED=y make install-dep bootstrap pkg-deb \
+ && UNATTENDED=y make vpp_configure_args_vpp='--disable-japi --disable-vom' install-dep bootstrap pkg-deb \
  && cd build-root \
  && bash -c "dpkg -i {vpp,vpp-plugins,vpp-lib,vpp-dev}_$(git describe --tags | sed -e s/-/~/2 -e s/^v//)_amd64.deb"


### PR DESCRIPTION
I just tested locally and adding just `vpp_configure_args_vpp='--disable-japi --disable-vom'` as described in #3 (without the `-disable-papi` as you did before)  decreases image size of **vpp-base-builder** by ~1.2GB and still contains `/usr/include/vpp-api/client/vppapiclient.h`.