### PR TITLE
hooks/build: don't use --pull on final image

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -7,4 +7,4 @@ set -xueo pipefail
 IMAGE_TAG="${VPP_COMMIT:0:8}"
 
 docker build --no-cache --pull -f Dockerfile-builder -t ${IMAGE_BUILDER_REPO}:${IMAGE_TAG} .
-docker build --no-cache --pull --build-arg BUILDER_IMAGE="${IMAGE_BUILDER_REPO}:${IMAGE_TAG}" -f Dockerfile -t ${IMAGE_REPO}:${IMAGE_TAG} .
+docker build --no-cache --build-arg BUILDER_IMAGE="${IMAGE_BUILDER_REPO}:${IMAGE_TAG}" -f Dockerfile -t ${IMAGE_REPO}:${IMAGE_TAG} .


### PR DESCRIPTION
This change avoids pulling the image and makes it use the built image. The built image would get ignored & it'd be pulled instead.

I've discovered this issue while testing #14.